### PR TITLE
Refactor evaluation with numba and seed run

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains an implementation of an Optimized Performance Based Gen
 ## Installation
 
 1. Create a Python environment (optional but recommended).
-2. Install dependencies:
+2. Install dependencies (Numba is used for fast evaluation):
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 matplotlib
 pytest
+numba


### PR DESCRIPTION
## Summary
- remove unused roulette selection code
- speed up chromosome evaluation with numba
- guard against zero-length task sets
- track makespan/DLM history during evolution
- seed numpy and Python RNGs for reproducibility
- note numba dependency in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855acc40a248320b4b5c4e76d4ba58f